### PR TITLE
Modifications allowing reset of all children fields of Prematch section

### DIFF
--- a/config/2024/config.json
+++ b/config/2024/config.json
@@ -5,7 +5,6 @@
   "sections": [
     {
       "name": "Prematch",
-      "preserveDataOnReset": true,
       "fields": [
         {
           "title": "Scouter Initials",

--- a/src/inputs/NumberInput.tsx
+++ b/src/inputs/NumberInput.tsx
@@ -19,7 +19,7 @@ export default function NumberInput(data: NumberInputProps) {
       type="number"
       min={data.min}
       max={data.max}
-      value={data.defaultValue}
+      value={data?.value || ''}
       id={data.title}
       onChange={handleChange}
     />


### PR DESCRIPTION
Currently, the `preserveDataOnReset` is at the section level. If on, then all children in the section would be saved and not reset. 

I've chosen to take it out with this PR as without it, it would not work. 