### PR TITLE
Fix notes in trap counts below zero

### DIFF
--- a/config/2024/config.json
+++ b/config/2024/config.json
@@ -148,6 +148,7 @@
           "type": "counter",
           "defaultValue": 0,
           "min": 0,
+          "max": 3,
           "required": false
         },
         {


### PR DESCRIPTION
Fixes #37

Update the 'Notes in Trap' field to restrict its value between 0 and 3.

* Modify `config/2024/config.json` to set the `min` property of the 'Notes in Trap' field to 0 and add a `max` property with a value of 3.
