### PR TITLE
add support for field descriptions

### DIFF
--- a/config/2024/config.json
+++ b/config/2024/config.json
@@ -10,12 +10,14 @@
       "fields": [
         {
           "title": "Scouter Initials",
+          "description": "Enter the initials of the scouter.",
           "type": "text",
           "required": true,
           "code": "scouter"
         },
         {
           "title": "Match Number",
+          "description": "Enter the match number.",
           "type": "number",
           "required": true,
           "code": "matchNumber",
@@ -24,6 +26,7 @@
         },
         {
           "title": "Robot",
+          "description": "The robot you are scouting this match, based on driver station position.",
           "type": "select",
           "required": true,
           "code": "robot",
@@ -39,12 +42,14 @@
         },
         {
           "title": "Team Number",
+          "description": "The team number of the robot you're scouting.",
           "type": "number",
           "required": true,
           "code": "teamNumber"
         },
         {
           "title": "Starting Position",
+          "description": "The starting position of the robot.",
           "type": "select",
           "required": true,
           "code": "Prsp",
@@ -57,6 +62,7 @@
         },
         {
           "title": "No Show",
+          "description": "Check if the robot did not show up for the match.",
           "type": "boolean",
           "defaultValue": false,
           "required": false,
@@ -69,6 +75,7 @@
       "fields": [
         {
           "title": "Moved?",
+          "description": "Check if the robot moved during autonomous.",
           "type": "boolean",
           "defaultValue": false,
           "required": false,
@@ -77,6 +84,7 @@
         {
           "code": "timer",
           "title": "Timer",
+          "description": "The time it took for the robot to finish autonomous.",
           "type": "timer",
           "defaultValue": 0,
           "required": false
@@ -84,6 +92,7 @@
         {
           "code": "ausc",
           "title": "Speaker Scored",
+          "description": "The number of speaker shots scored during autonomous.",
           "type": "counter",
           "defaultValue": 0,
           "min": 0,
@@ -92,6 +101,7 @@
         {
           "code": "auskpm",
           "title": "Speaker Missed",
+          "description": "The number of speaker shots missed during autonomous.",
           "type": "counter",
           "defaultValue": 0,
           "min": 0,

--- a/public/schema.json
+++ b/public/schema.json
@@ -32,6 +32,10 @@
                       "type": "string",
                       "description": "The title of the input"
                     },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the input"
+                    },
                     "type": {
                       "type": "string",
                       "const": "counter"
@@ -93,6 +97,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "text"
@@ -140,6 +147,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",
@@ -193,6 +203,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "select"
@@ -243,6 +256,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",
@@ -300,6 +316,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "boolean"
@@ -338,6 +357,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",

--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -32,6 +32,10 @@
                       "type": "string",
                       "description": "The title of the input"
                     },
+                    "description": {
+                      "type": "string",
+                      "description": "The description of the input"
+                    },
                     "type": {
                       "type": "string",
                       "const": "counter"
@@ -93,6 +97,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "text"
@@ -140,6 +147,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",
@@ -193,6 +203,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "select"
@@ -243,6 +256,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",
@@ -300,6 +316,9 @@
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
                     },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
                     "type": {
                       "type": "string",
                       "const": "boolean"
@@ -338,6 +357,9 @@
                   "properties": {
                     "title": {
                       "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
                     },
                     "type": {
                       "type": "string",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ export function Header() {
   return (
     <Helmet>
       <title>QRScout | {page_title}</title>
-      <link rel="icon" href="/favicon.ico" />
+      <link rel="icon" href="/QRScout/favicon.ico" />
     </Helmet>
   );
 }

--- a/src/components/Sections/FormSection.tsx
+++ b/src/components/Sections/FormSection.tsx
@@ -18,6 +18,7 @@ export default function FormSection(props: SectionProps) {
           title={e.title}
           required={e.required}
           hasValue={e.value !== null && e.value !== undefined && e.value !== ''}
+          description={e.description}
           key={`${props.name}_${e.title}`}
         >
           <ConfigurableInput section={props.name} code={e.code} />

--- a/src/components/inputs/BaseInputProps.ts
+++ b/src/components/inputs/BaseInputProps.ts
@@ -6,6 +6,7 @@ export const inputTypeSchema = z
 
 export const inputBaseSchema = z.object({
   title: z.string().describe('The title of the input'),
+  description: z.string().optional().describe('The description of the input'),
   type: inputTypeSchema,
   required: z.boolean().describe('Whether this input is required'),
   code: z.string().describe('A unique code for this input'),

--- a/src/components/inputs/InputCard.tsx
+++ b/src/components/inputs/InputCard.tsx
@@ -1,11 +1,19 @@
-import { TriangleAlert } from 'lucide-react';
+import { Info, TriangleAlert } from 'lucide-react';
 import React from 'react';
 import { Card, CardContent } from '../ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '../ui/dialog';
 
 export interface InputCardProps {
   title: string;
   required: boolean;
   hasValue: boolean;
+  description?: string;
 }
 
 export default function InputCard(
@@ -13,13 +21,26 @@ export default function InputCard(
 ) {
   return (
     <Card>
-      <div className="flex gap-2 bg-secondary px-1 items-center rounded-t-lg">
-        {props.required && !props.hasValue && (
-          <TriangleAlert className="text-primary animate-pulse size-4" />
+      <div className="flex justify-between bg-secondary px-1 items-center rounded-t-lg">
+        <div className="flex gap-2 ">
+          {props.required && !props.hasValue && (
+            <TriangleAlert className="text-primary animate-pulse size-4" />
+          )}
+          <h1 className="capitalize text-secondary-foreground text-sm">
+            {props.title.toUpperCase()}
+          </h1>
+        </div>
+        {props.description && (
+          <Dialog>
+            <DialogTrigger asChild>
+              <Info className="text-secondary-foreground size-4" />
+            </DialogTrigger>
+            <DialogContent>
+              <DialogTitle>{props.title}</DialogTitle>
+              <DialogDescription>{props.description}</DialogDescription>
+            </DialogContent>
+          </Dialog>
         )}
-        <h1 className="capitalize text-secondary-foreground text-sm">
-          {props.title.toUpperCase()}
-        </h1>
       </div>
       <CardContent className="p-0">{props.children}</CardContent>
     </Card>


### PR DESCRIPTION
If a field in the config has a `description` property, render an info icon and show the description in an overlay when clicked: 
![image](https://github.com/user-attachments/assets/733faa41-4998-45ca-b14f-daca17fdd377)

![image](https://github.com/user-attachments/assets/4454577d-db55-4801-b853-0109b7455da5)
