### PR TITLE
Fix form not acting correctly when config changes

### DIFF
--- a/src/components/inputs/CheckboxInput.tsx
+++ b/src/components/inputs/CheckboxInput.tsx
@@ -16,14 +16,15 @@ export default function CheckboxInput(props: ConfigurableInputProps) {
 
   const [checked, setChecked] = React.useState(data.defaultValue);
 
-  const resetState = React.useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = React.useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
     setChecked(data.defaultValue);
   }, [data.defaultValue]);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   useEffect(() => {
     updateValue(props.code, checked);

--- a/src/components/inputs/CounterInput.tsx
+++ b/src/components/inputs/CounterInput.tsx
@@ -17,11 +17,15 @@ export default function CounterInput(props: ConfigurableInputProps) {
 
   const [value, setValue] = useState(data.defaultValue);
 
-  const resetState = useCallback(() => {
+  const resetState = useCallback((force = false) => {
+    if(!force && (data.preserveDataOnReset || props.preserveSection)) {
+      return;
+    };
     setValue(data.defaultValue);
   }, []);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   const handleChange = useCallback(
     (increment: number) => {

--- a/src/components/inputs/NumberInput.tsx
+++ b/src/components/inputs/NumberInput.tsx
@@ -16,11 +16,11 @@ export default function NumberInput(props: ConfigurableInputProps) {
 
   const [value, setValue] = React.useState<number | ''>(data.defaultValue);
 
-  const resetState = useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
-    if (data.autoIncrementOnReset) {
+    if (!force && data.autoIncrementOnReset) {
       setValue(value ?? 0 + 1);
     } else {
       setValue(data.defaultValue);
@@ -28,6 +28,7 @@ export default function NumberInput(props: ConfigurableInputProps) {
   }, [data.defaultValue]);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   useEffect(() => {
     updateValue(props.code, value);

--- a/src/components/inputs/RangeInput.tsx
+++ b/src/components/inputs/RangeInput.tsx
@@ -16,14 +16,15 @@ export default function RangeInput(props: ConfigurableInputProps) {
 
   const [value, setValue] = useState(data.defaultValue);
 
-  const resetState = useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
     setValue(data.defaultValue);
   }, [data.defaultValue]);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   const handleChange = useCallback((value: number[]) => {
     setValue(value[0]);

--- a/src/components/inputs/SelectInput.tsx
+++ b/src/components/inputs/SelectInput.tsx
@@ -26,14 +26,15 @@ export default function SelectInput(props: ConfigurableInputProps) {
     updateValue(props.code, value);
   }, [value]);
 
-  const resetState = useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
     setValue(data.defaultValue);
   }, [data.defaultValue]);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   const handleSelect = useCallback((value: string) => {
     setValue(value);

--- a/src/components/inputs/StringInput.tsx
+++ b/src/components/inputs/StringInput.tsx
@@ -16,14 +16,15 @@ export default function StringInput(props: ConfigurableInputProps) {
 
   const [value, setValue] = React.useState(data.defaultValue);
 
-  const resetState = useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
     setValue(data.defaultValue);
   }, [data.defaultValue]);
 
   useEvent('resetFields', resetState);
+  useEvent('forceResetFields', () => resetState(true) );
 
   useEffect(() => {
     updateValue(props.code, value);

--- a/src/components/inputs/TimerInput.tsx
+++ b/src/components/inputs/TimerInput.tsx
@@ -31,8 +31,8 @@ export default function TimerInput(props: ConfigurableInputProps) {
 
   const average = useMemo(() => getAvg(times), [times]);
 
-  const resetState = useCallback(() => {
-    if (data.preserveDataOnReset || props.preserveSection) {
+  const resetState = useCallback((force = false) => {
+    if (!force && (data.preserveDataOnReset || props.preserveSection)) {
       return;
     }
 
@@ -43,7 +43,8 @@ export default function TimerInput(props: ConfigurableInputProps) {
   }, []);
 
   useEvent('resetFields', resetState);
-
+  useEvent('forceResetFields', () => resetState(true) );
+  
   function startStop() {
     toggleTimer(!isRunning);
   }

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -7,6 +7,7 @@ interface AppEvent<PayloadType = unknown> extends Event {
 export interface CustomWindowEventMap extends WindowEventMap {
   /* Custom Event */
   resetFields: AppEvent<string>;
+  forceResetFields: AppEvent<string>;
 }
 
 export const useEvent = <PayloadType = unknown>(

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -70,10 +70,17 @@ export function resetFields() {
   window.dispatchEvent(new CustomEvent('resetFields', { detail: 'reset' }));
 }
 
+export function forceResetFields() {
+  window.dispatchEvent(new CustomEvent('forceResetFields', { detail: 'forceReset' }));
+}
+
 export function setFormData(config: Config) {
   const oldState = useQRScoutState.getState();
-
-  useQRScoutState.setState({ ...oldState, formData: config });
+  forceResetFields();
+  const newFieldValues = config.sections.flatMap(s =>
+    s.fields.map(f => ({ code: f.code, value: f.defaultValue })),
+  );
+  useQRScoutState.setState({ ...oldState, fieldValues: newFieldValues, formData: config });
 }
 
 export function setConfig(configText: string): Result<void> {


### PR DESCRIPTION
Fixes:
When the config was edited, QRScout was reporting data based on the original config. (fixed by resetting the form after a config edit)
When the form reset after a config edit, values of inputs would change internally but the rendered input would not in inputs set to preserve their data on reset. (fixed by adding a "force reset" event that resets everything, regardless of it's supposed to be reset or not, since the form would have no reason not to reset after a config edit)