### PR TITLE
Fix entire page disapearing when theme buttons double-clicked

### DIFF
--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -2,7 +2,7 @@ import { useQRScoutState } from '@/store/store';
 import { setColorScheme } from '@/util/theme';
 import { createContext, useContext, useEffect, useState } from 'react';
 
-type Theme = 'dark' | 'light' | 'system';
+type Theme = 'dark' | 'light' | 'system' | '';
 
 type ThemeProviderProps = {
   children: React.ReactNode;

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -46,7 +46,6 @@ export function ThemeProvider({
 
   useEffect(() => {
     const root = window.document.documentElement;
-
     root.classList.remove('light', 'dark');
 
     if (theme === 'system') {
@@ -58,8 +57,13 @@ export function ThemeProvider({
       root.classList.add(systemTheme);
       return;
     }
-    setResolvedTheme(theme);
-    root.classList.add(theme);
+    
+    if(theme !== '') {
+      setResolvedTheme(theme);
+      root.classList.add(theme);
+    }
+    
+    
   }, [theme]);
 
   const value = {


### PR DESCRIPTION
When theme buttons (light mode, dark mode, and system theme buttons) are double-clicked, they make the entire page suddenly  disappear.

Temporarily fixed by not setting the style of the page if what it's supposed to become is a blank string (which is happening, despite type Theme being one of 'light', 'dark', or 'system').

The cause of this happening is currently unknown (to me, at least)