### PR TITLE
Add URL-based config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,31 @@ The basic structure of the config.json file is as follows:
 ```
 
 `defaultValue`: The default value of this field.
+
+## Loading JSON config from a URL
+
+QRScout now supports loading JSON config from a URL. This allows teams to host their config in a GitHub repository and then load the config directly from the URL.
+
+### Steps to load JSON config from a URL
+
+1. Open QRScout.
+2. Click on the "Settings" button at the bottom of the page.
+3. In the "Settings" menu, enter the URL of the JSON config in the input field labeled "Enter config URL".
+4. Click the "Load from URL" button.
+
+If the URL is valid and the JSON config is correctly formatted, QRScout will load the config and update the form fields accordingly.
+
+### Hosting JSON config in a GitHub repository
+
+To host your JSON config in a GitHub repository and make it available publicly via GitHub Pages, follow these steps:
+
+1. Create a new repository on GitHub or use an existing one.
+2. Add your JSON config file to the repository.
+3. Enable GitHub Pages for the repository:
+   - Go to the repository's "Settings" tab.
+   - Scroll down to the "GitHub Pages" section.
+   - Select the branch you want to use for GitHub Pages (e.g., `main` or `gh-pages`).
+   - Click "Save".
+4. After enabling GitHub Pages, your JSON config file will be available at a URL like `https://<username>.github.io/<repository>/<path-to-config>.json`.
+
+You can now use this URL to load the JSON config in QRScout.

--- a/README.md
+++ b/README.md
@@ -36,8 +36,28 @@ This has a number of buttons on it:
 - Download Config: Download the config.json file
 - Upload Config: Upload a config.json file
 - Reset Config to Default: Resets the config.json file to the default
+- Load from URL: Load a config.json file from a URL
 
 Beneath these, there are three buttons that control if QRScout is in light mode, dark mode, or your system's dark/light mode setting. By default, this is set to your system.
+
+Once you create a custom `config.json` file for your team, there are 2 ways to leverage it in competition:
+1. Download the custom `config.json` file to each tablet / device for your scouts and upload it to QRScout using the "Upload Config" button in the settings menu.
+2. Host the custom `config.json` file in a public GitHub repository and load it into QRScout using the "Load from URL" button in the settings menu.
+
+### Hosting a custom JSON config for your team
+
+To host your JSON config in a GitHub repository and make it available publicly via GitHub Pages, follow these steps:
+
+1. Create a new repository on GitHub or use an existing one.
+2. Add your JSON config file to the repository.
+3. Enable GitHub Pages for the repository:
+   - Go to the repository's "Settings" tab.
+   - Scroll down to the "GitHub Pages" section.
+   - Select the branch you want to use for GitHub Pages (e.g., `main`).
+   - Click "Save".
+4. After enabling GitHub Pages, your JSON config file will be available at a URL like `https://<username>.github.io/<repository>/<path-to-config>.json`.
+
+You can now use this URL to load the JSON config in QRScout.
 
 ## config.json
 
@@ -49,7 +69,7 @@ The basic structure of the config.json file is as follows:
 
 ### Root:
 
-`$schema`: A refrence to the schema used by the config.json file. This shouldn't be changed from the default "../schema.json".
+`$schema`: A reference to the schema used by the config.json file. This shouldn't be changed from the default "../schema.json".
 
 `title`: The title of the page. This is what appears in the tab bar.
 
@@ -93,31 +113,3 @@ The basic structure of the config.json file is as follows:
 ```
 
 `defaultValue`: The default value of this field.
-
-## Loading JSON config from a URL
-
-QRScout now supports loading JSON config from a URL. This allows teams to host their config in a GitHub repository and then load the config directly from the URL.
-
-### Steps to load JSON config from a URL
-
-1. Open QRScout.
-2. Click on the "Settings" button at the bottom of the page.
-3. In the "Settings" menu, enter the URL of the JSON config in the input field labeled "Enter config URL".
-4. Click the "Load from URL" button.
-
-If the URL is valid and the JSON config is correctly formatted, QRScout will load the config and update the form fields accordingly.
-
-### Hosting JSON config in a GitHub repository
-
-To host your JSON config in a GitHub repository and make it available publicly via GitHub Pages, follow these steps:
-
-1. Create a new repository on GitHub or use an existing one.
-2. Add your JSON config file to the repository.
-3. Enable GitHub Pages for the repository:
-   - Go to the repository's "Settings" tab.
-   - Scroll down to the "GitHub Pages" section.
-   - Select the branch you want to use for GitHub Pages (e.g., `main` or `gh-pages`).
-   - Click "Save".
-4. After enabling GitHub Pages, your JSON config file will be available at a URL like `https://<username>.github.io/<repository>/<path-to-config>.json`.
-
-You can now use this URL to load the JSON config in QRScout.

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -133,52 +133,70 @@ export function ConfigEditor(props: ConfigEditorProps) {
           onChange={value => value && setCurrentConfigText(value)}
         />
       </div>
-      <div className="flex flex-grow-0 justify-center items-center gap-4">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="secondary">
-              <Menu className="h-5 w-5" />
-              Options
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem onClick={() => resetToDefaultConfig()}>
-              Reset To Default Config
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={() => downloadConfig(config)}>
-              Download Config
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={handleUploadClick}>
-              Upload Config
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-        <div className="flex flex-col gap-2">
+      <div className="flex flex-col gap-4">
+        {/* Mobile view (<640px): URL input and button appear in a full-width row above other controls */}
+        <div className="flex flex-col sm:hidden gap-2 w-full">
           <Input
             type="url"
             placeholder="Enter config URL"
             value={url}
             onChange={e => setUrl(e.target.value)}
+            className="w-full"
           />
-          <Button onClick={handleLoadFromURL}>Load from URL</Button>
+          <Button onClick={handleLoadFromURL} className="w-full">Load from URL</Button>
         </div>
-        <Button
-          variant="destructive"
-          onClick={() => props.onSave && props.onSave(currentConfigText)}
-          disabled={currentConfigText.length === 0 || errorCount > 0}
-        >
-          <Save className="h-5 w-5" />
-          Save
-        </Button>
 
-        <Input
-          type="file"
-          ref={fileInputRef}
-          onChange={handleUploadChange}
-          className="hidden"
-          aria-hidden="true"
-          accept=".json,application/json"
-        />
+        {/* Desktop view (≥640px): URL input and button appear inline with other controls */}
+        <div className="flex flex-row items-center gap-4 flex-wrap">
+          <div className="hidden sm:flex flex-row items-center gap-2 flex-1">
+            <Input
+              type="url"
+              placeholder="Enter config URL"
+              value={url}
+              onChange={e => setUrl(e.target.value)}
+              className="flex-1 min-w-0"
+            />
+            <Button onClick={handleLoadFromURL}>Load from URL</Button>
+          </div>
+          
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="secondary">
+                <Menu className="h-5 w-5" />
+                Options
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              <DropdownMenuItem onClick={() => resetToDefaultConfig()}>
+                Reset To Default Config
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => downloadConfig(config)}>
+                Download Config
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={handleUploadClick}>
+                Upload Config
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+          
+          <Button
+            variant="destructive"
+            onClick={() => props.onSave && props.onSave(currentConfigText)}
+            disabled={currentConfigText.length === 0 || errorCount > 0}
+          >
+            <Save className="h-5 w-5" />
+            Save
+          </Button>
+
+          <Input
+            type="file"
+            ref={fileInputRef}
+            onChange={handleUploadChange}
+            className="hidden"
+            aria-hidden="true"
+            accept=".json,application/json"
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/ConfigEditor.tsx
+++ b/src/components/ConfigEditor.tsx
@@ -4,6 +4,7 @@ import { Menu, Save } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import schema from '../assets/schema.json';
 import {
+  fetchConfigFromURL,
   getConfig,
   resetToDefaultConfig,
   setConfig,
@@ -64,6 +65,7 @@ export function ConfigEditor(props: ConfigEditorProps) {
   const [errorCount, setErrorCount] = useState<number>(0);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
+  const [url, setUrl] = useState<string>('');
 
   useEffect(() => {
     setCurrentConfigText(JSON.stringify(config, null, 2));
@@ -105,6 +107,15 @@ export function ConfigEditor(props: ConfigEditorProps) {
     [],
   );
 
+  const handleLoadFromURL = useCallback(async () => {
+    const result = await fetchConfigFromURL(url);
+    if (!result.success) {
+      setError(result.error.message);
+    } else {
+      setError(null);
+    }
+  }, [url]);
+
   return (
     <div className="flex flex-col gap-2 h-full pb-2">
       <div className="flex-grow rounded-lg overflow-clip ">
@@ -142,6 +153,15 @@ export function ConfigEditor(props: ConfigEditorProps) {
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
+        <div className="flex flex-col gap-2">
+          <Input
+            type="url"
+            placeholder="Enter config URL"
+            value={url}
+            onChange={e => setUrl(e.target.value)}
+          />
+          <Button onClick={handleLoadFromURL}>Load from URL</Button>
+        </div>
         <Button
           variant="destructive"
           onClick={() => props.onSave && props.onSave(currentConfigText)}

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -50,6 +50,19 @@ export function resetToDefaultConfig() {
   useQRScoutState.setState(initialState);
 }
 
+export async function fetchConfigFromURL(url: string): Promise<Result<void>> {
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch config from URL: ${response.statusText}`);
+    }
+    const configText = await response.text();
+    return setConfig(configText);
+  } catch (error) {
+    return { success: false, error: error as Error };
+  }
+}
+
 export function updateValue(code: string, data: any) {
   useQRScoutState.setState(
     produce((state: QRScoutState) => {


### PR DESCRIPTION
Allow users to load their JSON form config from a URL.

When reading the [chiefdelphi thread about QRScout](https://www.chiefdelphi.com/t/qrscout-no-code-no-app-no-internet-no-problem/449456?u=ty_tremblay), I noticed teams were confused about how to leverage it.

It seems like most are creating a custom `config.json` file and then copying it all their tablets for scouts to use.
I documented that in the README but it also struck me as a suboptimal solution.

This PR proposes a way for teams to fetch their `config.json` file from an external endpoint so that they don't have to copy the file between their devices.
This makes sharing easier and ensures everyone has the most up-to-date version of the config.

It also adds some documentation on how to use GitHub pages to host a `config.json` file for free.

Demo https://drive.google.com/file/d/1uI8Eps3rP7EO5xeqF3H55zGm0nIqsfcJ/view?usp=sharing

Closes https://github.com/FRC2713/QRScout/issues/30