### PR TITLE
Fix QR modal scrolling issues

### DIFF
--- a/src/components/QR/QRModal.tsx
+++ b/src/components/QR/QRModal.tsx
@@ -37,11 +37,11 @@ export function QRModal(props: QRModalProps) {
           Commit
         </Button>
       </DialogTrigger>
-      <DialogContent>
+      <DialogContent className="h-[95%]">
         <DialogTitle className="text-3xl text-primary text-center font-rhr-ns tracking-wider ">
           {title}
         </DialogTitle>
-        <div className="flex flex-col items-center gap-6">
+        <div className="flex flex-col items-center gap-6 overflow-y-scroll">
           <div className="bg-white p-4 rounded-md">
             <QRCodeSVG className="m-2 mt-4" size={256} value={qrCodeData} />
           </div>


### PR DESCRIPTION
Fix QR modal being impossible to close on some small screens by defining its height as a percentage, and making the overflow mode of the flexbox containing the QR code's info written as a string to scroll.

Fixes #82

I have no idea how the QR modal's size is defined, so this might mess things up. I do know that it looks a bit elongated on large screens, but very few people are using QRScout in a match on a large display. I haven't had the chance to test these on small screens, but I have used Chrome's DevTools to test this at different pixel ratios, and they provide pixel ratios for a lot of mobile devices.

Might create issues for very small screens as the QR code might be cut off, however this probably isn't much of an issue due to the relative rarity of devices with extremely small screens (I'm talking about  < ~3in screens) that can also open QRScout that also don't lie about how large their screens are.