### PR TITLE
Add floating text box- Implement #85

### DIFF
--- a/config/2025/config.json
+++ b/config/2025/config.json
@@ -3,7 +3,10 @@
   "page_title": "Reefscape",
   "delimiter": "\t",
   "teamNumber": 2713,
-  "showTeamNumber": false,
+  "floatingField": {
+    "show": false,
+    "codeValue": "teamNumber"
+  },
   "theme": {
     "light": {
       "background": "0 0% 100%",

--- a/config/2025/config.json
+++ b/config/2025/config.json
@@ -3,6 +3,7 @@
   "page_title": "Reefscape",
   "delimiter": "\t",
   "teamNumber": 2713,
+  "showTeamNumber": false,
   "theme": {
     "light": {
       "background": "0 0% 100%",

--- a/public/schema.json
+++ b/public/schema.json
@@ -17,6 +17,10 @@
       "type": "number",
       "description": "The team number of the team using this form."
     },
+    "showTeamNumber": {
+      "type": "boolean",
+      "description": "Whether or not to always show the selected team number at the top of the screen"
+    },
     "theme": {
       "type": "object",
       "properties": {

--- a/public/schema.json
+++ b/public/schema.json
@@ -17,8 +17,18 @@
       "type": "number",
       "description": "The team number of the team using this form."
     },
-    "showTeamNumber": {
-      "type": "boolean",
+    "floatingField": {
+      "type": "object",
+      "properties": {
+        "show": {
+          "type": "boolean",
+          "description": "Whether or not to always show this value at the top of the screen. May be useful on small screens"
+        },
+        "codeValue": {
+          "type": "string",
+          "description": "Code of the form field to get this value from"
+        }
+      },
       "description": "Whether or not to always show the selected team number at the top of the screen"
     },
     "theme": {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -9,6 +9,7 @@ import { useQRScoutState } from './store/store';
 
 import { StatsigProvider, useClientAsyncInit } from '@statsig/react-bindings';
 import { runStatsigAutoCapture } from '@statsig/web-analytics';
+import { FloatingFormValue } from './components/FloatingFormValue';
 
 export function App() {
   const { teamNumber, pageTitle } = useQRScoutState(state => ({
@@ -35,7 +36,7 @@ export function App() {
             <h1 className="font-sans text-6xl font-bold">
               <div className={`font-rhr text-primary`}>{pageTitle}</div>
             </h1>
-
+            <FloatingFormValue />
             <form className="w-full px-4" onSubmit={e => e.preventDefault()}>
               <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                 <Sections />

--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -17,6 +17,10 @@
       "type": "number",
       "description": "The team number of the team using this form."
     },
+    "showTeamNumber": {
+      "type": "boolean",
+      "description": "Whether or not to always show the selected team number at the top of the screen"
+    },
     "theme": {
       "type": "object",
       "properties": {

--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -17,8 +17,18 @@
       "type": "number",
       "description": "The team number of the team using this form."
     },
-    "showTeamNumber": {
-      "type": "boolean",
+    "floatingField": {
+      "type": "object",
+      "properties": {
+        "show": {
+          "type": "boolean",
+          "description": "Whether or not to always show this value at the top of the screen. May be useful on small screens"
+        },
+        "codeValue": {
+          "type": "string",
+          "description": "Code of the form field to get this value from"
+        }
+      },
       "description": "Whether or not to always show the selected team number at the top of the screen"
     },
     "theme": {

--- a/src/components/FloatingFormValue.tsx
+++ b/src/components/FloatingFormValue.tsx
@@ -1,0 +1,14 @@
+import { useQRScoutState } from "@/store/store";
+
+export function FloatingFormValue() {
+    const showTeamNumber = useQRScoutState(state => state.formData.showTeamNumber);
+    const teamNumber = useQRScoutState(state => state.fieldValues).filter(f => f.code === 'teamNumber')[0].value;
+    const className = "sticky top-5 w-1/2 sm:w-full space-y-1.5 p-2 bg-primary mb-2 rounded-xl leading-none text-primary-foreground font-rhr-ns" + ((showTeamNumber)? "block" : "hidden");
+    console.log(className);
+    return (
+        <div
+        className={className}>
+            {teamNumber}
+        </div>
+    );
+}

--- a/src/components/FloatingFormValue.tsx
+++ b/src/components/FloatingFormValue.tsx
@@ -1,10 +1,9 @@
 import { useQRScoutState } from "@/store/store";
 
 export function FloatingFormValue() {
-    const showTeamNumber = useQRScoutState(state => state.formData.showTeamNumber);
-    const teamNumber = useQRScoutState(state => state.fieldValues).filter(f => f.code === 'teamNumber')[0].value;
-    const className = "sticky top-5 w-1/2 sm:w-full space-y-1.5 p-2 bg-primary mb-2 rounded-xl leading-none text-primary-foreground font-rhr-ns" + ((showTeamNumber)? "block" : "hidden");
-    console.log(className);
+    const {showField, codeValue} = useQRScoutState(state => {return {showField: state.formData.floatingField.show, codeValue: state.formData.floatingField.codeValue}});
+    const teamNumber = useQRScoutState(state => state.fieldValues).filter(f => f.code === codeValue)[0].value;
+    const className = "sticky top-5 w-1/2 sm:w-full space-y-1.5 p-2 bg-primary mb-2 rounded-xl leading-none text-primary-foreground font-rhr-ns " + ((showField)? "block" : "hidden");
     return (
         <div
         className={className}>

--- a/src/components/inputs/BaseInputProps.ts
+++ b/src/components/inputs/BaseInputProps.ts
@@ -174,6 +174,9 @@ export const configSchema = z.object({
   teamNumber: z
     .number()
     .describe('The team number of the team using this form.'),
+  showTeamNumber: z
+    .boolean()
+    .describe('Whether or not to always show the selected team number at the top of the screen. May be useful on small screens'),
   theme: themeSchema.default({
     light: {
       background: '0 0% 100%',

--- a/src/components/inputs/BaseInputProps.ts
+++ b/src/components/inputs/BaseInputProps.ts
@@ -174,9 +174,12 @@ export const configSchema = z.object({
   teamNumber: z
     .number()
     .describe('The team number of the team using this form.'),
-  showTeamNumber: z
-    .boolean()
-    .describe('Whether or not to always show the selected team number at the top of the screen. May be useful on small screens'),
+  floatingField: z
+    .object({
+      show: z.boolean().describe('Whether or not to always show this value at the top of the screen. May be useful on small screens'),
+      codeValue: z.string().describe('Code of the form field to get this value from')
+    })
+    .describe('Optional floating text box at the tob of the screen to show things like the team number. May be useful on small screens'),
   theme: themeSchema.default({
     light: {
       background: '0 0% 100%',


### PR DESCRIPTION
Adds an optional floating text box above the title that can be configured to show the value of any form input. This is disabled by default, but can be enabled (and configured) in the config.

The styling can be changed- I just copied what we were using in the headers of each form section, as long as the "sticky" class is present and the "top-(value)" class exists.