### PR TITLE
enable fetching schedule by year and update schema

### DIFF
--- a/public/schema.json
+++ b/public/schema.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "The title of the page"
     },
+    "year": {
+      "type": "number",
+      "description": "The year this scouting config is relevant for."
+    },
     "delimiter": {
       "type": "string",
       "description": "The delimiter to use when joining the form data"
@@ -698,6 +702,15 @@
                       "default": null,
                       "description": "Default value (null, as this input generates multiple fields)"
                     },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "tap",
+                        "hold"
+                      ],
+                      "default": "hold",
+                      "description": "Recording mode: 'tap' records instant timestamps on click, 'hold' records duration while button is pressed (default: 'hold')"
+                    },
                     "actions": {
                       "type": "array",
                       "items": {
@@ -728,12 +741,6 @@
                     "timerDuration": {
                       "type": "number",
                       "description": "Expected duration in seconds (for UI reference, e.g., 15 for auto, 135 for teleop)"
-                    },
-                    "mode": {
-                      "type": "string",
-                      "enum": ["tap", "hold"],
-                      "default": "hold",
-                      "description": "Recording mode: 'tap' records instant timestamps on click, 'hold' records duration while button is pressed (default: 'hold')"
                     }
                   },
                   "required": [
@@ -742,6 +749,112 @@
                     "required",
                     "code",
                     "actions"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "TBA-team-and-robot"
+                    },
+                    "required": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/required"
+                    },
+                    "code": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/code"
+                    },
+                    "disabled": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/disabled"
+                    },
+                    "formResetBehavior": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/formResetBehavior"
+                    },
+                    "defaultValue": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "teamNumber": {
+                              "type": "number"
+                            },
+                            "robotPosition": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "teamNumber",
+                            "robotPosition"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "The default team and robot position"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "type",
+                    "required",
+                    "code"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "TBA-match-number"
+                    },
+                    "required": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/required"
+                    },
+                    "code": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/code"
+                    },
+                    "disabled": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/disabled"
+                    },
+                    "formResetBehavior": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/formResetBehavior"
+                    },
+                    "defaultValue": {
+                      "type": "number",
+                      "default": 0,
+                      "description": "The default value"
+                    },
+                    "min": {
+                      "type": "number",
+                      "description": "The minimum value"
+                    },
+                    "max": {
+                      "type": "number",
+                      "description": "The maximum value"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "type",
+                    "required",
+                    "code"
                   ],
                   "additionalProperties": false
                 }
@@ -763,6 +876,7 @@
   "required": [
     "title",
     "page_title",
+    "year",
     "delimiter",
     "teamNumber",
     "sections"

--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -9,6 +9,10 @@
       "type": "string",
       "description": "The title of the page"
     },
+    "year": {
+      "type": "number",
+      "description": "The year this scouting config is relevant for."
+    },
     "delimiter": {
       "type": "string",
       "description": "The delimiter to use when joining the form data"
@@ -698,6 +702,15 @@
                       "default": null,
                       "description": "Default value (null, as this input generates multiple fields)"
                     },
+                    "mode": {
+                      "type": "string",
+                      "enum": [
+                        "tap",
+                        "hold"
+                      ],
+                      "default": "hold",
+                      "description": "Recording mode: 'tap' records instant timestamps on click, 'hold' records duration while button is pressed (default: 'hold')"
+                    },
                     "actions": {
                       "type": "array",
                       "items": {
@@ -728,12 +741,6 @@
                     "timerDuration": {
                       "type": "number",
                       "description": "Expected duration in seconds (for UI reference, e.g., 15 for auto, 135 for teleop)"
-                    },
-                    "mode": {
-                      "type": "string",
-                      "enum": ["tap", "hold"],
-                      "default": "hold",
-                      "description": "Recording mode: 'tap' records instant timestamps on click, 'hold' records duration while button is pressed (default: 'hold')"
                     }
                   },
                   "required": [
@@ -742,6 +749,112 @@
                     "required",
                     "code",
                     "actions"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "TBA-team-and-robot"
+                    },
+                    "required": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/required"
+                    },
+                    "code": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/code"
+                    },
+                    "disabled": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/disabled"
+                    },
+                    "formResetBehavior": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/formResetBehavior"
+                    },
+                    "defaultValue": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "teamNumber": {
+                              "type": "number"
+                            },
+                            "robotPosition": {
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "teamNumber",
+                            "robotPosition"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ],
+                      "default": null,
+                      "description": "The default team and robot position"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "type",
+                    "required",
+                    "code"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "title": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/title"
+                    },
+                    "description": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/description"
+                    },
+                    "type": {
+                      "type": "string",
+                      "const": "TBA-match-number"
+                    },
+                    "required": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/required"
+                    },
+                    "code": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/code"
+                    },
+                    "disabled": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/disabled"
+                    },
+                    "formResetBehavior": {
+                      "$ref": "#/properties/sections/items/properties/fields/items/anyOf/0/properties/formResetBehavior"
+                    },
+                    "defaultValue": {
+                      "type": "number",
+                      "default": 0,
+                      "description": "The default value"
+                    },
+                    "min": {
+                      "type": "number",
+                      "description": "The minimum value"
+                    },
+                    "max": {
+                      "type": "number",
+                      "description": "The maximum value"
+                    }
+                  },
+                  "required": [
+                    "title",
+                    "type",
+                    "required",
+                    "code"
                   ],
                   "additionalProperties": false
                 }
@@ -763,6 +876,7 @@
   "required": [
     "title",
     "page_title",
+    "year",
     "delimiter",
     "teamNumber",
     "sections"

--- a/src/components/QR/MatchDataFetcher.tsx
+++ b/src/components/QR/MatchDataFetcher.tsx
@@ -33,7 +33,9 @@ export function MatchDataFetcher({
         return;
       }
 
-      const result = await fetchTeamEvents(teamNumber);
+      const year = formData.year;
+
+      const result = await fetchTeamEvents(teamNumber, year);
 
       if (!result.success) {
         onError(result.error.message);
@@ -56,24 +58,21 @@ export function MatchDataFetcher({
     }
   }, [formData, onError]);
 
-  const handleEventSelected = useCallback(
-    async (eventKey: string) => {
-      const result = await fetchEventMatches(eventKey);
+  const handleEventSelected = useCallback(async (eventKey: string) => {
+    const result = await fetchEventMatches(eventKey);
 
-      if (!result.success) {
-        throw new Error(result.error.message);
-      }
+    if (!result.success) {
+      throw new Error(result.error.message);
+    }
 
-      if (result.data.length === 0) {
-        throw new Error('No match data available for this event yet');
-      }
+    if (result.data.length === 0) {
+      throw new Error('No match data available for this event yet');
+    }
 
-      // Store match data and close dialog
-      setMatchData(result.data);
-      setIsEventDialogOpen(false);
-    },
-    [],
-  );
+    // Store match data and close dialog
+    setMatchData(result.data);
+    setIsEventDialogOpen(false);
+  }, []);
 
   return (
     <>
@@ -103,4 +102,3 @@ export function MatchDataFetcher({
     </>
   );
 }
-

--- a/src/components/inputs/BaseInputProps.ts
+++ b/src/components/inputs/BaseInputProps.ts
@@ -230,7 +230,12 @@ export const configSchema = z.object({
       'The title of the scouting site. This will be displayed in the header and browser tab.',
     ),
   page_title: z.string().describe('The title of the page'),
-  year: z.number().describe('The year this scouting config is relevant for.'),
+  year: z
+    .number()
+    .optional()
+    .describe(
+      'The year this scouting config is relevant for. Defaults to the current year if not provided.',
+    ),
   delimiter: z
     .string()
     .describe('The delimiter to use when joining the form data'),

--- a/src/components/inputs/BaseInputProps.ts
+++ b/src/components/inputs/BaseInputProps.ts
@@ -103,11 +103,15 @@ export const imageInputSchema = inputBaseSchema.extend({
 
 export const actionSchema = z.object({
   label: z.string().describe('The display label for this action button'),
-  code: z.string().describe('A unique code for this action (used in field names)'),
+  code: z
+    .string()
+    .describe('A unique code for this action (used in field names)'),
   icon: z
     .string()
     .optional()
-    .describe('Optional Lucide icon name (e.g., "fuel", "target"). See https://lucide.dev/icons'),
+    .describe(
+      'Optional Lucide icon name (e.g., "fuel", "target"). See https://lucide.dev/icons',
+    ),
 });
 
 export const actionTrackerInputSchema = inputBaseSchema.extend({
@@ -129,7 +133,9 @@ export const actionTrackerInputSchema = inputBaseSchema.extend({
   timerDuration: z
     .number()
     .optional()
-    .describe('Expected duration in seconds (for UI reference, e.g., 15 for auto, 135 for teleop)'),
+    .describe(
+      'Expected duration in seconds (for UI reference, e.g., 15 for auto, 135 for teleop)',
+    ),
 });
 
 export const tbaTeamAndRobotInputSchema = inputBaseSchema.extend({
@@ -224,6 +230,7 @@ export const configSchema = z.object({
       'The title of the scouting site. This will be displayed in the header and browser tab.',
     ),
   page_title: z.string().describe('The title of the page'),
+  year: z.number().describe('The year this scouting config is relevant for.'),
   delimiter: z
     .string()
     .describe('The delimiter to use when joining the form data'),
@@ -232,11 +239,19 @@ export const configSchema = z.object({
     .describe('The team number of the team using this form.'),
   floatingField: z
     .object({
-      show: z.boolean().describe('Whether or not to always show this value at the top of the screen. May be useful on small screens'),
-      codeValue: z.string().describe('Code of the form field to get this value from')
+      show: z
+        .boolean()
+        .describe(
+          'Whether or not to always show this value at the top of the screen. May be useful on small screens',
+        ),
+      codeValue: z
+        .string()
+        .describe('Code of the form field to get this value from'),
     })
     .optional()
-    .describe('Optional floating text box at the tob of the screen to show things like the team number. May be useful on small screens'),
+    .describe(
+      'Optional floating text box at the tob of the screen to show things like the team number. May be useful on small screens',
+    ),
   theme: themeSchema.default({
     light: {
       background: '0 0% 100%',
@@ -310,7 +325,9 @@ export type TimerInputData = z.infer<typeof timerInputSchema>;
 export type ImageInputData = z.infer<typeof imageInputSchema>;
 export type ActionTrackerInputData = z.infer<typeof actionTrackerInputSchema>;
 export type ActionData = z.infer<typeof actionSchema>;
-export type TBATeamAndRobotInputData = z.infer<typeof tbaTeamAndRobotInputSchema>;
+export type TBATeamAndRobotInputData = z.infer<
+  typeof tbaTeamAndRobotInputSchema
+>;
 export type TBAMatchNumberInputData = z.infer<typeof tbaMatchNumberInputSchema>;
 
 export type InputPropsMap = {


### PR DESCRIPTION
* Adds an optional `year` field to the config.  
* `MatchDataFetcher` will try to use the year if it exists, defaults to current year otherwise.
* Updates the schema.