### PR TITLE
Render app before Statsig initializes

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -21,6 +21,11 @@ export function App() {
     {
       userID: `${teamNumber}`,
     },
+    {
+      networkConfig: {
+        networkTimeoutMs: 2000,
+      },
+    },
   );
 
   useEffect(() => {
@@ -28,7 +33,7 @@ export function App() {
   }, [client]);
 
   return (
-    <StatsigProvider client={client} loadingComponent={<div>Loading...</div>}>
+    <StatsigProvider client={client}>
       <ThemeProvider>
         <div className="min-h-screen py-2">
           <Header />


### PR DESCRIPTION
This makes the UI render immediately (no loading gate) and shortens Statsig network timeouts to 2s. For reference, Statsig's default network timeout is 10,000 ms (10s).