### PR TITLE
fix: prevent device long-press context menu on action tracker buttons

### DIFF
--- a/src/components/inputs/ActionTrackerInput.tsx
+++ b/src/components/inputs/ActionTrackerInput.tsx
@@ -487,9 +487,10 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
               key={action.code}
               variant="secondary"
               className={cn(
-                'h-auto min-h-16 flex-col gap-1 text-wrap py-3 touch-none select-none',
+                'h-auto min-h-16 flex-col gap-1 text-wrap py-3 touch-none select-none [-webkit-touch-callout:none]',
                 isBeingHeld && 'ring-2 ring-primary ring-offset-2 !bg-primary/20 animate-pulse',
               )}
+              onContextMenu={e => e.preventDefault()}
               onPointerDown={e => handlePointerDown(e, action.code)}
               onPointerMove={handlePointerMove}
               onPointerUp={e => {


### PR DESCRIPTION
- Add onContextMenu preventDefault so OS context menu (Download/Share/Print) does not interrupt press-and-hold behavior on mobile
- Add -webkit-touch-callout:none to suppress iOS callout on long press Fixes issue where holding >0.5s triggered device long-press instead of app hold, preventing release and data recording

Made-with: Cursor