### PR TITLE
Remove old single-increment fuel counter

### DIFF
--- a/config/2026/config.json
+++ b/config/2026/config.json
@@ -186,17 +186,6 @@
                     }
                 },
                 {
-                    "title": "Fuel Scored in Auto?",
-                    "description": "The number of fuel scored in autonomous.",
-                    "type": "counter",
-                    "required": false,
-                    "code": "autoFuelScored",
-                    "formResetBehavior": "reset",
-                    "defaultValue": 0,
-                    "min": 0,
-                    "step": 1
-                },
-                {
                     "title": "Fuel Scored",
                     "description": "Approximate fuel scored during teleop.",
                     "type": "multi-counter",


### PR DESCRIPTION
Follow-up to #102. Now that we have the multi-counter with +1/+5/+10 buttons, the old single-increment counter in auto is redundant. This removes it.