### PR TITLE
Fix match number increment

### DIFF
--- a/src/components/inputs/TBAMatchNumberInput.tsx
+++ b/src/components/inputs/TBAMatchNumberInput.tsx
@@ -52,9 +52,14 @@ export default function TBAMatchNumberInput(props: ConfigurableInputProps) {
       if (data.formResetBehavior === 'preserve') {
         return;
       }
+      if (data.formResetBehavior === 'increment') {
+        const newValue = (value == '') ? value : value + 1;
+        setValue(newValue);
+        return;
+      }
       setValue(data.defaultValue);
     },
-    [data.defaultValue, data.formResetBehavior],
+    [data.defaultValue, data.formResetBehavior, value],
   );
 
   useEvent('resetFields', resetState);

--- a/src/components/inputs/TBAMatchNumberInput.tsx
+++ b/src/components/inputs/TBAMatchNumberInput.tsx
@@ -53,13 +53,12 @@ export default function TBAMatchNumberInput(props: ConfigurableInputProps) {
         return;
       }
       if (data.formResetBehavior === 'increment') {
-        const newValue = (value == '') ? value : value + 1;
-        setValue(newValue);
+        setValue(prev => typeof prev === 'number' ? prev + 1 : data.defaultValue);
         return;
       }
       setValue(data.defaultValue);
     },
-    [data.defaultValue, data.formResetBehavior, value],
+    [data.defaultValue, data.formResetBehavior],
   );
 
   useEvent('resetFields', resetState);


### PR DESCRIPTION
Hi! I'm a mentor for [FRC 6201](https://thehighlanders6201.weebly.com/). We noticed the match number from The Blue Alliance prefill was not automatically incrementing after resetting the form, even when configured. This fix worked for us. Hope it helps!