### PR TITLE
Fix action tracker hold getting permanently stuck on tablets

### DIFF
--- a/src/components/inputs/ActionTrackerInput.tsx
+++ b/src/components/inputs/ActionTrackerInput.tsx
@@ -79,11 +79,27 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
     () => new Map(),
   );
 
+  // Ref mirror of activePointers so event handlers always see the latest state
+  // (avoids stale closure bugs where pointerup fires before React re-renders)
+  const activePointersRef = useRef<Map<number, ActivePointer>>(new Map());
+
   // Pending pointers (hold mode) - before intent is confirmed
   const pendingPointersRef = useRef<Map<number, PendingPointer>>(new Map());
 
   // Pending taps (tap mode) - for scroll detection
   const pendingTapsRef = useRef<Map<number, PendingTap>>(new Map());
+
+  // Helper: update activePointers state AND ref in sync
+  const updateActivePointers = useCallback(
+    (updater: (prev: Map<number, ActivePointer>) => Map<number, ActivePointer>) => {
+      setActivePointers(prev => {
+        const next = updater(prev);
+        activePointersRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
 
   // Determine mode (defaults to 'hold')
   const isHoldMode = data.mode !== 'tap';
@@ -112,7 +128,7 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
         setElapsedTime(0);
         setAutoStarted(false);
         setActionLog([]);
-        setActivePointers(new Map()); // Clear any active holds
+        updateActivePointers(() => new Map()); // Clear any active holds
         elapsedAccumulatorRef.current = 0;
         if (animationFrameRef.current !== null) {
           cancelAnimationFrame(animationFrameRef.current);
@@ -145,7 +161,7 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
       setIsRunning(false);
 
       // Finalize any active holds at the auto-stop time
-      setActivePointers(prev => {
+      updateActivePointers(prev => {
         if (prev.size === 0) return prev;
         const endTime = Number((autoStopMs / 1000).toFixed(1));
         setActionLog(log => [
@@ -266,7 +282,7 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
 
           const startTime = Number((elapsedAccumulatorRef.current / 1000).toFixed(1));
 
-          setActivePointers(prev => {
+          updateActivePointers(prev => {
             const next = new Map(prev);
             next.set(pointerId, { actionCode, startTime });
             return next;
@@ -345,18 +361,24 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
         return; // Don't record - wasn't held long enough
       }
 
-      // For CONFIRMED holds: only end on pointerup
-      // Ignore pointercancel and pointerleave - user is still holding,
-      // the browser just got confused by finger movement
-      if (e.type === 'pointercancel' || e.type === 'pointerleave') {
+      // For CONFIRMED holds: ignore pointerleave only.
+      // pointercancel is a TERMINAL event on mobile — no pointerup follows,
+      // so we must treat it as an end event to avoid stuck holds.
+      if (e.type === 'pointerleave') {
         return;
       }
 
-      // Handle confirmed active pointer (only on pointerup)
-      const active = activePointers.get(e.pointerId);
+      // Handle confirmed active pointer (pointerup or pointercancel)
+      // Read from ref to avoid stale closure — state may not have
+      // re-rendered yet when rapid pointer events fire
+      const active = activePointersRef.current.get(e.pointerId);
       if (!active) return;
 
-      e.currentTarget.releasePointerCapture(e.pointerId);
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // Pointer capture may already be released (e.g. after pointercancel)
+      }
 
       const endTime = Number((elapsedAccumulatorRef.current / 1000).toFixed(1));
 
@@ -370,7 +392,7 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
         },
       ]);
 
-      setActivePointers(prev => {
+      updateActivePointers(prev => {
         const next = new Map(prev);
         next.delete(e.pointerId);
         return next;
@@ -378,7 +400,7 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
 
       vibrate([30, 20, 30]); // Double buzz on release
     },
-    [isHoldMode, activePointers, cancelPendingPointer],
+    [isHoldMode, cancelPendingPointer, updateActivePointers],
   );
 
   // Tap mode: handle pointer up - record action if not cancelled by scroll
@@ -412,26 +434,28 @@ export default function ActionTrackerInput(props: ConfigurableInputProps) {
       pendingTapsRef.current.clear();
 
       // Record all confirmed active holds as completed
-      if (activePointers.size === 0) return;
+      // Use ref to get latest state without needing it as a dependency
+      const current = activePointersRef.current;
+      if (current.size === 0) return;
 
       const endTime = Number((elapsedAccumulatorRef.current / 1000).toFixed(1));
 
       // Record all active holds as completed
       setActionLog(prev => [
         ...prev,
-        ...Array.from(activePointers.values()).map(p => ({
+        ...Array.from(current.values()).map(p => ({
           actionCode: p.actionCode,
           timestamp: p.startTime,
           endTimestamp: endTime,
         })),
       ]);
 
-      setActivePointers(new Map());
+      updateActivePointers(() => new Map());
     };
 
     window.addEventListener('blur', handleBlur);
     return () => window.removeEventListener('blur', handleBlur);
-  }, [activePointers]);
+  }, [updateActivePointers]);
 
   // Cleanup pending pointer timers on unmount
   useEffect(() => {


### PR DESCRIPTION
Got a report that sometimes on tablets, pressing and releasing an action button in hold mode leaves the button stuck in the "held" state (glowing ring + pulse). Only way out was refreshing the page.

**Video of the bug:**
https://github.com/user-attachments/assets/83bef037-a7b5-4614-8395-cf0a75685c08

## What was happening

To be honest, I couldn't reproduce this bug on our tablet, but this is what the AI says:

Two things going on:

1. `pointercancel` was being ignored for confirmed holds. The idea was that the browser might fire spurious cancels while the user is still holding, but on mobile `pointercancel` is actually a terminal event (no `pointerup` follows). So when the OS decides to cancel the touch (palm rejection, finger hitting the bezel, gesture takeover, etc.), the hold just never ends.

2. `handlePointerEnd` was reading `activePointers` from its React state closure, but with rapid tapping the state could be stale (not yet re-rendered), so the handler would miss the pointer ID entirely and silently skip cleanup.

## Fix

- Treat `pointercancel` as a valid end event for confirmed holds (same as `pointerup`). Only `pointerleave` is still ignored.
- Added a ref mirror of `activePointers` so event handlers always read the latest state regardless of render timing.
- Wrapped `releasePointerCapture` in try/catch since it can throw after a `pointercancel`.
