### PR TITLE
Fix teleop fuel field being listed under Auto

### DIFF
--- a/config/2026/config.json
+++ b/config/2026/config.json
@@ -186,15 +186,6 @@
                     }
                 },
                 {
-                    "title": "Fuel Scored",
-                    "description": "Approximate fuel scored during teleop.",
-                    "type": "multi-counter",
-                    "required": false,
-                    "code": "teleopFuelScored",
-                    "formResetBehavior": "reset",
-                    "defaultValue": 0
-                },
-                {
                     "title": "Alliance won auto?",
                     "description": "Did your alliance win the autonomous period?",
                     "type": "boolean",
@@ -208,6 +199,15 @@
         {
             "name": "Teleop",
             "fields": [
+                {
+                    "title": "Fuel Scored",
+                    "description": "Approximate fuel scored during teleop.",
+                    "type": "multi-counter",
+                    "required": false,
+                    "code": "teleopFuelScored",
+                    "formResetBehavior": "reset",
+                    "defaultValue": 0
+                },
                 {
                     "title": "Actions",
                     "description": "Track actions performed during teleop.",


### PR DESCRIPTION
Move the `teleopFuelScored` field out of the _Auto_ section and into _Teleop_ where it should've been in the first place
<img width="609" height="795" alt="image" src="https://github.com/user-attachments/assets/e436b438-51d5-4b75-b389-00be05b469ee" />
