### PR TITLE
Fix TBA week label off-by-one in event picker

### DIFF
--- a/src/components/QR/EventSelectionDialog.tsx
+++ b/src/components/QR/EventSelectionDialog.tsx
@@ -83,7 +83,10 @@ export function EventSelectionDialog({
                   </p>
                   {event.short_name && (
                     <p className="text-xs text-muted-foreground mt-1">
-                      {event.short_name} (Week {event.week})
+                      {event.short_name}
+                      {event.week !== null && event.week !== undefined
+                        ? ` (Week ${event.week + 1})`
+                        : ''}
                     </p>
                   )}
                 </CardContent>


### PR DESCRIPTION
## Summary
- Fix TBA event week display off-by-one error from raw `week` to `week + 1` in the event selection dialog
- Hide the week label when TBA returns `null`/`undefined` to avoid errors

TBA returns official event weeks as zero-based values.

## Before
<img width="488" height="372" alt="image" src="https://github.com/user-attachments/assets/e4ded3c0-ae56-4886-ba8e-13fd83402542" />

## After
<img width="488" height="375" alt="image" src="https://github.com/user-attachments/assets/ec71662a-38d2-47dd-b152-d9ef7123a320" />
