### PR TITLE
Fix resetting of fields on config update to avoid visual desync

### DIFF
--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -84,6 +84,7 @@ export const useQRScoutState = createStore<QRScoutState>(
 );
 
 export function resetToDefaultConfig() {
+  forceResetFields(); // clicking 'x' instead of Save can prevent a `setFormData` call
   useQRScoutState.setState(initialState);
 }
 
@@ -119,12 +120,12 @@ export function getFieldValue(code: string) {
 }
 
 export function resetFields() {
-  window.dispatchEvent(new CustomEvent('resetFields', { detail: 'reset' }));
+  window.dispatchEvent(new CustomEvent('resetFields', { detail: { force: false } }));
 }
 
 export function forceResetFields() {
   window.dispatchEvent(
-    new CustomEvent('forceResetFields', { detail: 'forceReset' }),
+    new CustomEvent('resetFields', { detail: { force: true } }),
   );
 }
 


### PR DESCRIPTION
The `forceResetFields` function in [src/store/store.ts](https://github.com/FRC2713/QRScout/blob/134265d857bf638156ee28751104490c715b39c7/src/store/store.ts#L125) dispatches an event of type 'forceResetFields' which isn't referenced or handled anywhere else in the code as far as I could tell. Additionally, the resetFields function seems to have the wrong shape for its dispatch of the 'resetFields' event, using { detail: 'reset' } instead of {detail: { force: false } }. The former of these caused the fields to not reset when the config was changed, meaning that they would still look populated despite having the default value until updated.