### PR TITLE
Sanitize newlines in QR serialized text fields

### DIFF
--- a/src/components/QR/QRModal.tsx
+++ b/src/components/QR/QRModal.tsx
@@ -12,6 +12,10 @@ import {
 } from '../ui/dialog';
 import { PreviewText } from './PreviewText';
 
+function removeNewlines(value: string): string {
+  return value.replace(/\r\n|\r|\n/g, ' ');
+}
+
 /** Serialize a field value for QR code or display; TBA-team-and-robot is stored as an object. */
 function fieldValueToQrString(value: unknown): string {
   if (value != null && typeof value === 'object' && 'teamNumber' in value) {
@@ -19,7 +23,7 @@ function fieldValueToQrString(value: unknown): string {
     return String(teamNumber);
   }
   if (value === null || value === undefined) return '';
-  return String(value);
+  return removeNewlines(String(value));
 }
 
 export interface QRModalProps {


### PR DESCRIPTION
Scouts sometimes press Enter in text fields (especially `Comments`), which adds newlines to the QR payload and causes spreadsheet scans to break into extra rows.

This change sanitizes serialized field values in `src/components/QR/QRModal.tsx` by replacing `\r\n`, `\r`, and `\n` with spaces before encoding/copying QR data.

The data still shows up with `\n` in the commit modal, but when you click "Copy Data" it sanitizes that out.

<img width="974" height="258" alt="CleanShot 2026-04-22 at 12 12 36@2x" src="https://github.com/user-attachments/assets/3bee1039-63e1-4640-9ec7-e2113357b921" />

<img width="342" height="330" alt="CleanShot 2026-04-22 at 12 16 22@2x" src="https://github.com/user-attachments/assets/b9260676-5689-4878-a098-9be4f3d9d794" />

